### PR TITLE
feat: adds cors support

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -81,6 +81,7 @@
 		"body-parser": "^1.19.0",
 		"compression": "^1.7.4",
 		"connect-redis": "^6.1.3",
+		"cors": "^2.8.5",
 		"css-loader": "^5.0.1",
 		"express": "^4.16.4",
 		"env-var": "^7.1.1",

--- a/app/src/config/config.js
+++ b/app/src/config/config.js
@@ -32,6 +32,16 @@ module.exports = {
 			sslKey: env.get('SSL_KEY').asString(),
 			sslKeyPassphrase: env.get('SSL_KEY_PASSWORD').asString()
 		},
+		cors: {
+			// @link: https://www.npmjs.com/packages/cors#configuration-options
+			config: {
+				// origin: "*",
+				origin: false, //enable cors via this line
+				methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+				preflightContinue: false,
+				optionsSuccessStatus: 204,
+			}
+		},
 		session: {
 			name: 'connect.id',
 			// Force everyone to have a session even if they are not logged in.

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -21,11 +21,12 @@ module.exports = async function main(webpackConfig) {
 
 	// Start setting up our server
 	logger.info('Initializing server');
-	let server = new Server()
+	let server = new Server(config.server)
 		.configureMiddleware()
 		.configureSession()
 		.configurePassport()
 		.configureHelmet()
+		.configureCores()
 		.configureViewEngine('pug', config.files.views)
 		.configureLocals(config.locals);
 


### PR DESCRIPTION
## Acceptance Criteria
The App now supports cors request out of the box via a config

## Change Description
CORS is something it should be able to support and adding it is trivial. Now that has been done. It also makes the express class closer to being stateless

## Verification Instructions
Run the app and run `curl -XOPTIONS -I localhost:3000/api/user/login -H "Origin: www.google.com`
Confirm there is now CORS headers return 
Update the config to allow all domains and rerun the test
confirm that cors headers are now returned

## Commit Message
feat: Adds cors to the starter
fix: Makes the express class more stateless
