### PR TITLE
Feat/add secrets support

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -3,7 +3,7 @@ FROM golang
 # Update our image
 RUN echo "Updating base container" && \
     apt-get -y update && \
-    apt-get -y install zip python3 python3-pip && \
+    apt-get -y install zip python3 python3-pip vim && \
     apt-get -y upgrade && \
     pip install awscli && \
     apt-get clean && \
@@ -16,11 +16,11 @@ RUN echo "Updating base container" && \
     git clone https://github.com/cunymatthieu/tgenv.git ~/.tgenv && \
     ln -s ~/.tgenv/bin/* /usr/local/bin && \
     echo "Installing SOPS" && \
-    go install go.mozilla.org/sops/v3/cmd/sops@v3.7.1
+    go install go.mozilla.org/sops/v3/cmd/sops@v3.7.3
 
 RUN tfenv install 1.3.3 && \
     tfenv use 1.3.3 && \
     tgenv install 0.39.2 && \
-    bash -c "source ~/.bashrc && nvm install 17"
+    bash -c "source ~/.bashrc && nvm install 18"
 
 WORKDIR /root/repo

--- a/devops/terraform/modules/fargate-service/input.tf
+++ b/devops/terraform/modules/fargate-service/input.tf
@@ -73,6 +73,11 @@ variable "loadbalancer_subnets" {
   description = "Subnets to run the load balancer in (public/private)"
 }
 
+variable region {
+  type = string
+  description = "Region to deploy the service to"
+}
+
 variable "tags" {
   type        = map(any)
   description = "Tags to apply to all resources. Ie: environment, cost tracking, etc..."
@@ -118,4 +123,10 @@ variable "health_check_path" {
   type        = string
   default     = "/api/healthcheck"
   description = "Path to the healthcheck endpoint"
+}
+
+variable secrets {
+  type = list(map(string))
+  default = []
+  description = "List of secrets to attach to the service"
 }

--- a/devops/terraform/modules/fargate-service/input.tf
+++ b/devops/terraform/modules/fargate-service/input.tf
@@ -73,8 +73,8 @@ variable "loadbalancer_subnets" {
   description = "Subnets to run the load balancer in (public/private)"
 }
 
-variable region {
-  type = string
+variable "region" {
+  type        = string
   description = "Region to deploy the service to"
 }
 
@@ -125,8 +125,8 @@ variable "health_check_path" {
   description = "Path to the healthcheck endpoint"
 }
 
-variable secrets {
-  type = list(map(string))
-  default = []
+variable "secrets" {
+  type        = list(map(string))
+  default     = []
   description = "List of secrets to attach to the service"
 }

--- a/devops/terraform/modules/fargate-service/main.tf
+++ b/devops/terraform/modules/fargate-service/main.tf
@@ -1,8 +1,8 @@
-module secrets {
+module "secrets" {
   source = "../secrets"
 
-  secrets = var.secrets
-  region = var.region
+  secrets         = var.secrets
+  region          = var.region
   recovery_window = 0
 }
 

--- a/devops/terraform/modules/fargate-service/main.tf
+++ b/devops/terraform/modules/fargate-service/main.tf
@@ -43,7 +43,7 @@ module "image" {
   image        = var.image_tag == null ? "${var.service_name}:latest" : var.image_tag
   log_group    = aws_cloudwatch_log_group.logs.name
   env_vars     = var.env_vars
-  secrets      = module.secrets.env_map
+  secrets      = module.secrets.fargate_secrets
   port_mappings = [
     {
       containerPort = var.container_port

--- a/devops/terraform/modules/fargate-service/main.tf
+++ b/devops/terraform/modules/fargate-service/main.tf
@@ -1,3 +1,11 @@
+module secrets {
+  source = "../secrets"
+
+  secrets = var.secrets
+  region = var.region
+  recovery_window = 0
+}
+
 resource "aws_ecs_cluster" "cluster" {
   count = var.create_new_cluster ? 1 : 0
   name  = var.cluster_name
@@ -35,11 +43,16 @@ module "image" {
   image        = var.image_tag == null ? "${var.service_name}:latest" : var.image_tag
   log_group    = aws_cloudwatch_log_group.logs.name
   env_vars     = var.env_vars
+  secrets      = module.secrets.env_map
   port_mappings = [
     {
       containerPort = var.container_port
       hostPort      = var.container_port
     }
+  ]
+
+  depends_on = [
+    module.secrets
   ]
 }
 

--- a/devops/terraform/modules/secrets/input.tf
+++ b/devops/terraform/modules/secrets/input.tf
@@ -1,28 +1,34 @@
-variable secrets {
-  type = list(map(string))
-  default = []
+variable "secrets" {
+  type        = list(map(string))
+  default     = []
   description = "Map of secrets to store in aws secrets manager"
 }
 
-variable kms_key_id {
-    type = string
-    default = null
-    description = "Name of the kms key to associate with the secrets"
+variable "kms_key_id" {
+  type        = string
+  default     = null
+  description = "Name of the kms key to associate with the secrets"
 }
 
-variable create_kms_key {
-  type = bool
-  default = false
+variable "create_new_key" {
+  type        = bool
+  default     = true
+  description = "Create a new key to encrypt the secrets data with"
+}
+
+variable "create_kms_key" {
+  type        = bool
+  default     = false
   description = "Set to true to create a new kms key with the given name or false to use an existing key"
 }
 
-variable region {
-    type = string
-    description = "Region for replicating the secret in"
+variable "region" {
+  type        = string
+  description = "Region for replicating the secret in"
 }
 
-variable recovery_window {
-    type = number
-    default = 7
-    description = "Number of days, 0 to 30, to store a deleted secret in order to recover it"
+variable "recovery_window" {
+  type        = number
+  default     = 7
+  description = "Number of days, 0 to 30, to store a deleted secret in order to recover it"
 }

--- a/devops/terraform/modules/secrets/input.tf
+++ b/devops/terraform/modules/secrets/input.tf
@@ -1,0 +1,28 @@
+variable secrets {
+  type = list(map(string))
+  default = []
+  description = "Map of secrets to store in aws secrets manager"
+}
+
+variable kms_key_id {
+    type = string
+    default = null
+    description = "Name of the kms key to associate with the secrets"
+}
+
+variable create_kms_key {
+  type = bool
+  default = false
+  description = "Set to true to create a new kms key with the given name or false to use an existing key"
+}
+
+variable region {
+    type = string
+    description = "Region for replicating the secret in"
+}
+
+variable recovery_window {
+    type = number
+    default = 7
+    description = "Number of days, 0 to 30, to store a deleted secret in order to recover it"
+}

--- a/devops/terraform/modules/secrets/main.tf
+++ b/devops/terraform/modules/secrets/main.tf
@@ -1,0 +1,18 @@
+# resource "aws_kms_key" key {
+
+# }
+
+resource "aws_secretsmanager_secret" secret {
+    count = length(var.secrets)
+
+    name = var.secrets[count.index].name
+    kms_key_id = var.kms_key_id
+    recovery_window_in_days = var.recovery_window
+}
+
+resource "aws_secretsmanager_secret_version" secret {
+    count = length(var.secrets)
+
+    secret_id = aws_secretsmanager_secret.secret[count.index].id
+    secret_string = jsonencode(var.secrets[count.index].value)
+}

--- a/devops/terraform/modules/secrets/main.tf
+++ b/devops/terraform/modules/secrets/main.tf
@@ -2,9 +2,26 @@
 
 # }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_secretsmanager_secret" secret {
     count = length(var.secrets)
 
+    policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+            {
+                Action = "secretsmanager:*"
+                Effect = "Allow"
+                Principal = {
+                    AWS = "${data.aws_caller_identity.current.account_id}:root"
+                }
+                # Gross and misleading I know, but it has to be star
+                # As it is attached to a single secret and AWS needs a resource line
+                Resource = "*"
+            }
+        ]
+    })
     name = var.secrets[count.index].name
     kms_key_id = var.kms_key_id
     recovery_window_in_days = var.recovery_window

--- a/devops/terraform/modules/secrets/main.tf
+++ b/devops/terraform/modules/secrets/main.tf
@@ -1,35 +1,57 @@
-# resource "aws_kms_key" key {
-
-# }
-
 data "aws_caller_identity" "current" {}
 
-resource "aws_secretsmanager_secret" secret {
-    count = length(var.secrets)
+resource "aws_kms_key" "key" {
+  count = var.create_new_key ? 1 : 0
 
-    policy = jsonencode({
-        Version = "2012-10-17"
-        Statement = [
-            {
-                Action = "secretsmanager:*"
-                Effect = "Allow"
-                Principal = {
-                    AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:federated-user/root"
-                }
-                # Gross and misleading I know, but it has to be star
-                # As it is attached to a single secret and AWS needs a resource line
-                Resource = "*"
-            }
-        ]
-    })
-    name = var.secrets[count.index].name
-    kms_key_id = var.kms_key_id
-    recovery_window_in_days = var.recovery_window
+  description             = "Secrets key"
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = [
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          ]
+        }
+        # Gross and misleading I know, but it has to be star
+        # As it is attached to a single secret and AWS needs a resource line
+        Resource = "*"
+      }
+    ]
+  })
 }
 
-resource "aws_secretsmanager_secret_version" secret {
-    count = length(var.secrets)
+resource "aws_secretsmanager_secret" "secret" {
+  count = length(var.secrets)
 
-    secret_id = aws_secretsmanager_secret.secret[count.index].id
-    secret_string = jsonencode(var.secrets[count.index].value)
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "secretsmanager:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:federated-user/root"
+        }
+        # Gross and misleading I know, but it has to be star
+        # As it is attached to a single secret and AWS needs a resource line
+        Resource = "*"
+      }
+    ]
+  })
+  name                    = var.secrets[count.index].name
+  kms_key_id              = var.create_new_key ? aws_kms_key.key[0].key_id : var.kms_key_id
+  recovery_window_in_days = var.recovery_window
+}
+
+resource "aws_secretsmanager_secret_version" "secret" {
+  count = length(var.secrets)
+
+  secret_id     = aws_secretsmanager_secret.secret[count.index].id
+  secret_string = jsonencode(var.secrets[count.index].value)
 }

--- a/devops/terraform/modules/secrets/main.tf
+++ b/devops/terraform/modules/secrets/main.tf
@@ -14,7 +14,7 @@ resource "aws_secretsmanager_secret" secret {
                 Action = "secretsmanager:*"
                 Effect = "Allow"
                 Principal = {
-                    AWS = "${data.aws_caller_identity.current.account_id}:root"
+                    AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:federated-user/root"
                 }
                 # Gross and misleading I know, but it has to be star
                 # As it is attached to a single secret and AWS needs a resource line

--- a/devops/terraform/modules/secrets/output.tf
+++ b/devops/terraform/modules/secrets/output.tf
@@ -1,11 +1,11 @@
-output env_map {
-    value = [for k,v in var.secrets: {name = v.env_name, arn = aws_secretsmanager_secret.secret[k].arn}]
+output "env_map" {
+  value = [for k, v in var.secrets : { name = v.env_name, arn = aws_secretsmanager_secret.secret[k].arn }]
 }
 
-output fargate_secrets {
-    value = [for k,v in var.secrets: {name = v.env_name, valueFrom = aws_secretsmanager_secret.secret[k].arn}]
+output "fargate_secrets" {
+  value = [for k, v in var.secrets : { name = v.env_name, valueFrom = aws_secretsmanager_secret.secret[k].arn }]
 }
 
-output secret_map {
-    value = [for k,v in var.secrets: {name = v.name, arn = aws_secretsmanager_secret.secret[k].arn}]
+output "secret_map" {
+  value = [for k, v in var.secrets : { name = v.name, arn = aws_secretsmanager_secret.secret[k].arn }]
 }

--- a/devops/terraform/modules/secrets/output.tf
+++ b/devops/terraform/modules/secrets/output.tf
@@ -1,0 +1,7 @@
+output env_map {
+    value = [for k,v in var.secrets: {name = v.env_name, valueFrom = aws_secretsmanager_secret.secret[k].arn}]
+}
+
+output secret_map {
+    value = [for k,v in var.secrets: {name = v.name, valueFrom = aws_secretsmanager_secret.secret[k].arn}]
+}

--- a/devops/terraform/modules/secrets/output.tf
+++ b/devops/terraform/modules/secrets/output.tf
@@ -1,7 +1,11 @@
 output env_map {
+    value = [for k,v in var.secrets: {name = v.env_name, arn = aws_secretsmanager_secret.secret[k].arn}]
+}
+
+output fargate_secrets {
     value = [for k,v in var.secrets: {name = v.env_name, valueFrom = aws_secretsmanager_secret.secret[k].arn}]
 }
 
 output secret_map {
-    value = [for k,v in var.secrets: {name = v.name, valueFrom = aws_secretsmanager_secret.secret[k].arn}]
+    value = [for k,v in var.secrets: {name = v.name, arn = aws_secretsmanager_secret.secret[k].arn}]
 }

--- a/devops/terraform/modules/task-definition/iam.tf
+++ b/devops/terraform/modules/task-definition/iam.tf
@@ -18,6 +18,11 @@ resource "aws_iam_role" "task_role" {
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   ]
 
+  inline_policy {
+    name = "AppPermissions"
+    policy = var.permissions
+  }
+
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax.
   assume_role_policy = jsonencode({
@@ -50,6 +55,21 @@ resource "aws_iam_role" "task_execution_role" {
     "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   ]
+
+  inline_policy {
+    name = "SecretsAccess"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = "secretsmanager:GetSecretValue"
+          Effect = "Allow"
+          Sid    = ""
+          Resource = [for secret in var.secrets : secret.valueFrom]
+        }
+      ]
+    })
+  }
 
   # Terraform's "jsonencode" function converts a
   # Terraform expression result to valid JSON syntax.

--- a/devops/terraform/modules/task-definition/iam.tf
+++ b/devops/terraform/modules/task-definition/iam.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "task_role" {
   ]
 
   inline_policy {
-    name = "AppPermissions"
+    name   = "AppPermissions"
     policy = var.permissions
   }
 
@@ -62,9 +62,9 @@ resource "aws_iam_role" "task_execution_role" {
       Version = "2012-10-17"
       Statement = [
         {
-          Action = "secretsmanager:GetSecretValue"
-          Effect = "Allow"
-          Sid    = ""
+          Action   = "secretsmanager:GetSecretValue"
+          Effect   = "Allow"
+          Sid      = ""
           Resource = [for secret in var.secrets : secret.valueFrom]
         }
       ]

--- a/devops/terraform/modules/task-definition/input.tf
+++ b/devops/terraform/modules/task-definition/input.tf
@@ -35,6 +35,12 @@ variable "port_mappings" {
   ]
 }
 
+variable permissions {
+  type = string
+  default = null
+  description = "Json encoded string of permissions to attach to the container"
+}
+
 variable "env_vars" {
   type        = map(string)
   default     = {}
@@ -53,7 +59,10 @@ variable "tags" {
 }
 
 variable secrets {
-  type = list(map(string))
+  type = list(object({
+    name = string
+    valueFrom = string
+  }))
   default = []
   description = "Secrets to load into the container's environment"
 }

--- a/devops/terraform/modules/task-definition/input.tf
+++ b/devops/terraform/modules/task-definition/input.tf
@@ -51,3 +51,9 @@ variable "tags" {
   description = "Tags to apply to all resources. Ie: environment, cost tracking, etc..."
   default     = {}
 }
+
+variable secrets {
+  type = list(map(string))
+  default = []
+  description = "Secrets to load into the container's environment"
+}

--- a/devops/terraform/modules/task-definition/input.tf
+++ b/devops/terraform/modules/task-definition/input.tf
@@ -35,9 +35,9 @@ variable "port_mappings" {
   ]
 }
 
-variable permissions {
-  type = string
-  default = null
+variable "permissions" {
+  type        = string
+  default     = null
   description = "Json encoded string of permissions to attach to the container"
 }
 
@@ -58,11 +58,11 @@ variable "tags" {
   default     = {}
 }
 
-variable secrets {
+variable "secrets" {
   type = list(object({
-    name = string
+    name      = string
     valueFrom = string
   }))
-  default = []
+  default     = []
   description = "Secrets to load into the container's environment"
 }

--- a/devops/terraform/modules/task-definition/main.tf
+++ b/devops/terraform/modules/task-definition/main.tf
@@ -28,6 +28,7 @@ resource "aws_ecs_task_definition" "service" {
           "awslogs-stream-prefix" = "streaming"
         }
       }
+      secrets = var.secrets
     }
   ])
 


### PR DESCRIPTION
## Acceptance Criteria
The starting terragrunt file can now give a list of secrets from a sops encrypted file and pass that onto the fargate service

## Change Description
Adds the ability to encode secrets into a containers environment using secrets manager

## Verification Instructions
Create a fargate service and add in a list of secrets to the terragrunt config
verify that the container task definition contains a secrets portion
verify that the contains can become stable after turning on

## Commit Message
feat: Adds secrets support to terraform
