### PR TITLE
feat: the secrets module now announces it's kms key and fargate gives…

### DIFF
--- a/devops/terraform/modules/fargate-service/main.tf
+++ b/devops/terraform/modules/fargate-service/main.tf
@@ -4,7 +4,7 @@ module "secrets" {
   secrets         = var.secrets
   region          = var.region
   # @TODO: Fix the permissions when using a customer managed key
-  create_new_key  = false
+  create_new_key  = true
   recovery_window = 0
 }
 
@@ -47,6 +47,7 @@ module "image" {
   log_group    = aws_cloudwatch_log_group.logs.name
   env_vars     = var.env_vars
   secrets      = module.secrets.fargate_secrets
+  secrets_keys = module.secrets.kms_key != null ? [module.secrets.kms_key] : []
   port_mappings = [
     {
       containerPort = var.container_port

--- a/devops/terraform/modules/secrets/output.tf
+++ b/devops/terraform/modules/secrets/output.tf
@@ -9,3 +9,8 @@ output "fargate_secrets" {
 output "secret_map" {
   value = [for k, v in var.secrets : { name = v.name, arn = aws_secretsmanager_secret.secret[k].arn }]
 }
+
+output kms_key {
+  description = "ARN of the kms key used to encrypt the secrets"
+  value = var.create_kms_key ? aws_kms_key.key[0].arn : null
+}

--- a/devops/terraform/modules/task-definition/iam.tf
+++ b/devops/terraform/modules/task-definition/iam.tf
@@ -60,14 +60,22 @@ resource "aws_iam_role" "task_execution_role" {
     name = "SecretsAccess"
     policy = jsonencode({
       Version = "2012-10-17"
-      Statement = [
+      Statement = concat([
         {
           Action   = "secretsmanager:GetSecretValue"
           Effect   = "Allow"
           Sid      = ""
           Resource = [for secret in var.secrets : secret.valueFrom]
+        }], length(var.secrets_keys) == 0 ? [] : [
+        {
+          Action   = [
+            "kms:Decrypt"
+          ]
+          Effect   = "Allow"
+          Sid      = ""
+          Resource = var.secrets_keys
         }
-      ]
+      ])
     })
   }
 

--- a/devops/terraform/modules/task-definition/input.tf
+++ b/devops/terraform/modules/task-definition/input.tf
@@ -66,3 +66,9 @@ variable "secrets" {
   default     = []
   description = "Secrets to load into the container's environment"
 }
+
+variable secrets_keys {
+  type = list(string)
+  default = []
+  description = "If there are any kms keys used with the secrets, add them here"
+}


### PR DESCRIPTION
## Acceptance Criteria
A container can use secrets encrypted with a customer managed key instead of an aws managed key

## Change Description
A container can use secrets encrypted with a customer managed key instead of an aws managed key

## Verification Instructions
Deploy the fargate service with some secrets. Have the secrets module create a new key and pass the arn to the task definition to update the permissions. A container should be able to start 

## Commit Message
feat: Customer managed keys now supported by the fargate service
