### PR TITLE
Fixes the secrets module from having two inputs for the same thing

### DIFF
--- a/devops/terraform/modules/secrets/input.tf
+++ b/devops/terraform/modules/secrets/input.tf
@@ -16,12 +16,6 @@ variable "create_new_key" {
   description = "Create a new key to encrypt the secrets data with"
 }
 
-variable "create_kms_key" {
-  type        = bool
-  default     = false
-  description = "Set to true to create a new kms key with the given name or false to use an existing key"
-}
-
 variable "region" {
   type        = string
   description = "Region for replicating the secret in"

--- a/devops/terraform/modules/secrets/output.tf
+++ b/devops/terraform/modules/secrets/output.tf
@@ -12,5 +12,5 @@ output "secret_map" {
 
 output "kms_key" {
   description = "ARN of the kms key used to encrypt the secrets"
-  value       = var.create_kms_key ? aws_kms_key.key[0].arn : null
+  value       = var.create_new_key ? aws_kms_key.key[0].arn : null
 }


### PR DESCRIPTION
## Acceptance Criteria
Deploying the fargate service works again with custom kms secrets

## Change Description
fix: fargate supports custom kms secrets

## Verification Instructions
deploy the fargate service with a self manage key and confirm the service starts

## Commit Message
fix: fargate supports custom kms secrets
