### PR TITLE
Feat/add lambda secrets

### DIFF
--- a/app/Entrypoint.sh
+++ b/app/Entrypoint.sh
@@ -15,7 +15,7 @@ if [ -f "/srv/server.key" ]; then
     export SSL_KEY="$(cat /srv/server.key)"
 fi
 
-if [[ "$1" == "s3-build" ]]; then
+if [ "$1" = "s3-build" ]; then
     if [ -d "/srv/bin/public" ]; then
         rm -rf /srv/bin/public/*
     fi

--- a/app/src/lambda/ReadMe.md
+++ b/app/src/lambda/ReadMe.md
@@ -18,6 +18,11 @@ This is the single biggest difference between the normal server code and the lam
 
 This is the main invocation file, it sources the routes.js file to learn its options and then forwards the requests from lambda to the appropriate handler.
 
+## Secrets
+
+Out of the bos this support AWS Secrets Manager, ASM, and uses a built in cache class to lazy load secrets. If you would like to use the secrets extension, add the config.yml file 
+to the desired lambda folder. That also works equally well but requires that you specify all needed secrets both in a yaml and terragrunt instead of just terragrunt
+
 ### Overwriting this file
 
 If you need more specific handler behavior for a lambda, you can copy the index.js file and put it in the lambda folder. It will be used instead of the shared handler

--- a/app/src/lambda/health/controller.js
+++ b/app/src/lambda/health/controller.js
@@ -4,7 +4,7 @@
  * @param {Express.Request} _req - Express request object
  * @param {Express.Response} res - Express response object
  */
-module.exports.healthcheck = function healthcheck(event) {
+module.exports.healthcheck = async function healthcheck(event, cache) {
 	console.log('Health check endpoint hit');
 	return {
     statusCode: 200,

--- a/app/src/lambda/index.js
+++ b/app/src/lambda/index.js
@@ -6,8 +6,8 @@ const fs = require('fs');
 const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
 const ROUTES_PATTERN = process.env['ROUTES_PATTERN'] || 'routes.js';
-// Lazy load the secrets manager to avoid loading in aws untill needed (saves time and money)
-let secretsManager = undefined;
+// Load aws ahead of the handler as this can take a while to execute
+const { SecretsManager } = require('aws-sdk');
 
 const adjustRoutes = ({routes, prefix}) => {
   return Object.keys(routes).reduce((agg, route) => {
@@ -45,38 +45,55 @@ const routes = getFiles(__dirname).then(files => {
   }, {});
 });
 
-
+/**
+ * @class Cache
+ * @summary: Basic cache to be shared across invocations of the lambda handler. This will save time
+ * In only needing to get items out of the cache as needed vs every invocation saving time and cost
+ */
 class Cache {
-  constructor(refreshTime) {
-    this.refreshTime = refreshTime
-    this.cache = {}
+  /**
+   * 
+   * @param {number} refreshTime - Time in ms for how long before an item in cache is considered too old to use
+   */
+  constructor(refreshTime, secretsManager) {
+    this.cache = {};
+    this.refreshTime = refreshTime;
+    this.secretsManager = secretsManager;
   }
 
+  /**
+   * @summary - Retrieves an item out of aws secrets manager if the key is too old or not in the cache.
+   * @param {string} key - Name of the secret in AWS secrets manager to pull 
+   * @returns Promise<String> - Promise containing the secret even if the value is resolved
+   */
   getSecret(key) {
-    if (!secretsManager) {
-      secretsManager = new (require('aws-sdk').SecretsManager)();
-    }
-
     if (!this.cache[key] || this.cache[key].time + this.refreshTime > new Date().valueOf()) {
       this.cache[key] = {
         time: new Date().valueOf(),
-        value: secretsManager.getSecretValue({SecretId: key}).promise().then(secret => {
+        value: this.secretsManager.getSecretValue({SecretId: key}).promise().then(secret => {
           if ('SecretString' in secret) {
             return secret.SecretString;
           }
           let buff = Buffer.from(secret.SecretBinary, 'base64');
-          return decodedBinarySecret = buff.toString('ascii');
+          return buff.toString('ascii');
         })
       };
     }
     return this.cache[key].value;
   }
 
+  /**
+   * @summary - Manually clears an item from the cache
+   * @param {string} key - Key of the cache item to clear
+   */
   clearCacheItem(key) {
     if (this.cache[key])
       delete this.cache[key];
   }
 
+  /**
+   * @summary - Resets the entire cache
+   */
   clearCache() {
     delete this.cache;
     this.cache = {};
@@ -84,10 +101,10 @@ class Cache {
 }
 
 // 5 minute cache
-const cache = new Cache(1000 * 60 * 5);
+const cache = new Cache(1000 * 60 * 5, new SecretsManager());
 
 module.exports.handler = async (event) => {
-  // console.log('Event: ', event);
+  console.log('Event: ', event);
 
   // @TODO add support for the ANY method on an endpoint
   let options = await routes;

--- a/app/src/lambda/index.js
+++ b/app/src/lambda/index.js
@@ -6,6 +6,8 @@ const fs = require('fs');
 const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
 const ROUTES_PATTERN = process.env['ROUTES_PATTERN'] || 'routes.js';
+// Lazy load the secrets manager to avoid loading in aws untill needed (saves time and money)
+let secretsManager = undefined;
 
 const adjustRoutes = ({routes, prefix}) => {
   return Object.keys(routes).reduce((agg, route) => {
@@ -44,20 +46,57 @@ const routes = getFiles(__dirname).then(files => {
 });
 
 
+class Cache {
+  constructor(refreshTime) {
+    this.refreshTime = refreshTime
+    this.cache = {}
+  }
 
-// @TODO add secrets support
+  getSecret(key) {
+    if (!secretsManager) {
+      secretsManager = new (require('aws-sdk').SecretsManager)();
+    }
+
+    if (!this.cache[key] || this.cache[key].time + this.refreshTime > new Date().valueOf()) {
+      this.cache[key] = {
+        time: new Date().valueOf(),
+        value: secretsManager.getSecretValue({SecretId: key}).promise().then(secret => {
+          if ('SecretString' in secret) {
+            return secret.SecretString;
+          }
+          let buff = Buffer.from(secret.SecretBinary, 'base64');
+          return decodedBinarySecret = buff.toString('ascii');
+        })
+      };
+    }
+    return this.cache[key].value;
+  }
+
+  clearCacheItem(key) {
+    if (this.cache[key])
+      delete this.cache[key];
+  }
+
+  clearCache() {
+    delete this.cache;
+    this.cache = {};
+  }
+}
+
+// 5 minute cache
+const cache = new Cache(1000 * 60 * 5);
+
 module.exports.handler = async (event) => {
-  console.log('Event: ', event);
+  // console.log('Event: ', event);
 
   // @TODO add support for the ANY method on an endpoint
   let options = await routes;
-  console.log(options)
   const option = event.requestContext.resourceId;
   try {
     if (options[option]) {
-      return options[option](event);
+      return options[option](event, cache);
     } else if (options[event.requestContext.httpMethod + ' $default']) {
-      return options[event.requestContext.httpMethod + ' $default'](event);
+      return options[event.requestContext.httpMethod + ' $default'](event, cache);
     }
     console.error('No matching endpoint found');
     return;

--- a/app/src/lambda/user/controler.js
+++ b/app/src/lambda/user/controler.js
@@ -5,7 +5,7 @@ const userService = require('./service');
  * @param {Express.Request} req - Express request object
  * @param {Express.Response} res - Express response object
  */
-module.exports.getActiveUser = function getActiveUser(event) {
+module.exports.getActiveUser = function getActiveUser(event, cache) {
 	// TODO: Add error handling when adding real implementation
 	return {
     statusCode: 200,
@@ -22,7 +22,7 @@ module.exports.getActiveUser = function getActiveUser(event) {
  * @param {Express.Request} req - Express request object
  * @param {Express.Response} res - Express response object
  */
-module.exports.login = function login(event) {
+module.exports.login = function login(event, cache) {
 	// TODO: Implement user authentication
 	return {
     statusCode: 200,

--- a/devops/terraform/modules/lambda-with-api/input.tf
+++ b/devops/terraform/modules/lambda-with-api/input.tf
@@ -25,6 +25,24 @@ variable "lambda_name" {
   description = "Name for the lambda function"
 }
 
+variable "secrets" {
+  type = object({
+    arns     = list(string)
+    kms_keys = list(string)
+  })
+  description = "List of secrets and associated kms keys the lambda will need access to"
+  default = {
+    arns     = []
+    kms_keys = []
+  }
+}
+
+variable "permissions" {
+  type        = map(any)
+  description = "Additional permissions the lambda will need"
+  default     = null
+}
+
 variable "path_prefix" {
   type        = string
   description = "Common path shared between all endpoints"

--- a/devops/terraform/modules/lambda-with-api/main.tf
+++ b/devops/terraform/modules/lambda-with-api/main.tf
@@ -15,6 +15,8 @@ module "lambda" {
   source = "../lambda"
 
   environment_vars = var.environment_vars
+  secrets          = var.secrets
+  permissions      = var.permissions
   bucket           = var.bucket_name
   key              = var.bucket_key
   function_name    = var.lambda_name

--- a/devops/terraform/modules/lambda/input.tf
+++ b/devops/terraform/modules/lambda/input.tf
@@ -42,3 +42,21 @@ variable "environment_vars" {
   default     = null
   description = "Environment variables to pass into the lambda"
 }
+
+variable "secrets" {
+  type = object({
+    arns     = list(string)
+    kms_keys = list(string)
+  })
+  description = "List of secrets and associated kms keys the lambda will need access to"
+  default = {
+    arns     = []
+    kms_keys = []
+  }
+}
+
+variable "permissions" {
+  type        = map(any)
+  description = "Additional permissions the lambda will need"
+  default     = null
+}

--- a/devops/terraform/modules/secrets/output.tf
+++ b/devops/terraform/modules/secrets/output.tf
@@ -1,13 +1,17 @@
 output "env_map" {
-  value = [for k, v in var.secrets : { name = v.env_name, arn = aws_secretsmanager_secret.secret[k].arn }]
+  value = [for k, v in var.secrets : { name = v.env_name, arn = aws_secretsmanager_secret.secret[k].arn } if lookup(v, "env_name", null) != null]
 }
 
 output "fargate_secrets" {
-  value = [for k, v in var.secrets : { name = v.env_name, valueFrom = aws_secretsmanager_secret.secret[k].arn }]
+  value = [for k, v in var.secrets : { name = v.env_name, valueFrom = aws_secretsmanager_secret.secret[k].arn } if lookup(v, "env_name", null) != null]
 }
 
 output "secret_map" {
   value = [for k, v in var.secrets : { name = v.name, arn = aws_secretsmanager_secret.secret[k].arn }]
+}
+
+output "arn_map" {
+  value = { for k, v in var.secrets : v.name => aws_secretsmanager_secret.secret[k].arn }
 }
 
 output "kms_key" {

--- a/devops/terraform/modules/serverless-app/input.tf
+++ b/devops/terraform/modules/serverless-app/input.tf
@@ -30,6 +30,16 @@ variable "function_configs" {
   description = "Config for all of the lambdas to produce"
 }
 
+variable "addition_function_configs" {
+  type = map(object({
+    permissions = map(any)
+    secrets     = set(string)
+    env_vars    = map(string)
+  }))
+  default     = {}
+  description = "Addition configs for all of the lambdas to have"
+}
+
 variable "create_ui_bucket" {
   type        = bool
   default     = true
@@ -65,4 +75,16 @@ variable "s3_prefix" {
 variable "ui_files" {
   type        = string
   description = "Absolute path to the files to serve via s3"
+}
+
+variable "secrets" {
+  type        = list(map(string))
+  default     = []
+  description = "List of secrets to attach to the service"
+}
+
+variable "region" {
+  type        = string
+  description = "Region being deployed in AWS"
+  default     = "us-east-1"
 }

--- a/devops/terragrunt-examples/aws/serverless-fullstack/terragrunt.hcl
+++ b/devops/terragrunt-examples/aws/serverless-fullstack/terragrunt.hcl
@@ -26,11 +26,6 @@ inputs = {
       s3Uri = "test2.zip"
       prefix = "/api/healthcheck"
       routes = ["GET /api/healthcheck"]
-      # permissions = null
-      # secrets = []
-      # env_vars = merge(local.default_env_vars, {
-        
-      # })
     },
     user = {
       s3Uri = "test2.zip"
@@ -42,6 +37,30 @@ inputs = {
     }
   }
   function_configs = local.function_configs
+  addition_function_configs = {
+    health = {
+      permissions = null
+      secrets = [
+        "superSecretApiKey"
+      ]
+      env_vars = merge(local.default_env_vars, {
+        
+      })
+    }
+    user = {
+      permissions = null
+      secrets = []
+      env_vars = merge(local.default_env_vars, {
+        
+      })
+    }
+  }
+  secrets = [
+    {
+      name = "superSecretApiKey"
+      value = "omg don't tell no one"
+    },
+  ]
   create_s3_bucket = true
   ui_bucket_name = "NAME_FOR_THE_UI_BUCKET"
   # If you are not using an existing ACM cert, you will need to do multiple deploys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     ports:
       - "3000:3000"
     environment:
+      # In case the .aws folder doesn't have this set already
+      AWS_REGION: us-east-1
       ENVIRONMENT: local
       LOG_LEVEL: debug
       DB_USER: foo
@@ -30,10 +32,15 @@ services:
       ENABLE_SSL: false
       SSL_KEY_PASSWORD: DO_NOT_USE_THIS
     volumes:
+      # Enables live reload on code changes
       - "./app/src:/srv/src"
+      # Allows the app to build the ui for us
       - "./app/bin:/srv/bin"
+      # Keep the cert out of the build using volumes
       - "./app/certs/example.cert:/srv/server.cert"
       - "./app/certs/example.key:/srv/server.key"
+      # enable aws access
+      - ~/.aws:/root/.aws
     depends_on:
     #   - mongo
       - redis
@@ -50,7 +57,7 @@ services:
     volumes:
       # Store the history
       - devops_history:/root/bash_history
-      # Volume in the repo rather than copying it
+      # Volume in the repo rather than copying it (saves time on start)
       - ./:/root/repo
       # Just in case we have any ssh to deal with
       - $HOME/.ssh:/root/.ssh


### PR DESCRIPTION
## Acceptance Criteria
lambda functions can now easily pull secrets from secrets manager

## Change Description
lambda functions can now easily pull secrets from secrets manager when deployed

## Verification Instructions
Deploy the serverless app and insert code to pull the fake secret. The function should able to pull it without erroring or timing out

## Commit Message
feat: gives lambda the ability to pull secrets easily
fix: fixes the app container not being able to use the s3 build shortcut
feat: adds aws credentials to the app container for testing the aws sdk
