### PR TITLE
Fix/local dev lambda endpoints

### DIFF
--- a/app/src/lambda/ReadMe.md
+++ b/app/src/lambda/ReadMe.md
@@ -23,6 +23,13 @@ This is the main invocation file, it sources the routes.js file to learn its opt
 Out of the bos this support AWS Secrets Manager, ASM, and uses a built in cache class to lazy load secrets. If you would like to use the secrets extension, add the config.yml file 
 to the desired lambda folder. That also works equally well but requires that you specify all needed secrets both in a yaml and terragrunt instead of just terragrunt
 
-### Overwriting this file
+## The $default path
+
+The API Gateway supports only 1 default endpoint no matter how many lambdas or stages you have deployed. If you plan to use a default endpoint, it is recommended you make its own
+lambda for it with its own appropriate prefix. Possible all of /api or whatever may be needed if the case ever happens.
+
+If you had to have multiple default endpoints, you would need 1 api gateway per default lambda which at the moment is not supported
+
+### Overwriting the index.js file
 
 If you need more specific handler behavior for a lambda, you can copy the index.js file and put it in the lambda folder. It will be used instead of the shared handler

--- a/app/src/lambda/health/controller.js
+++ b/app/src/lambda/health/controller.js
@@ -14,3 +14,13 @@ module.exports.healthcheck = async function healthcheck(event, cache) {
     body: JSON.stringify('OK'),
   }
 };
+module.exports.default = async function (event, cache) {
+	console.log('Health check endpoint hit');
+	return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify('default'),
+  }
+};

--- a/app/src/lambda/health/controller.js
+++ b/app/src/lambda/health/controller.js
@@ -14,13 +14,3 @@ module.exports.healthcheck = async function healthcheck(event, cache) {
     body: JSON.stringify('OK'),
   }
 };
-module.exports.default = async function (event, cache) {
-	console.log('Health check endpoint hit');
-	return {
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify('default'),
-  }
-};

--- a/app/src/lambda/health/routes.js
+++ b/app/src/lambda/health/routes.js
@@ -3,7 +3,6 @@ const controller = require('./controller');
 module.exports = {
     prefix: '/api/healthcheck',
     routes: {
-        'GET ': controller.healthcheck,
-        '$default': controller.default
+        'GET ': controller.healthcheck
     }
 }

--- a/app/src/lambda/health/routes.js
+++ b/app/src/lambda/health/routes.js
@@ -3,6 +3,7 @@ const controller = require('./controller');
 module.exports = {
     prefix: '/api/healthcheck',
     routes: {
-        'GET ': controller.healthcheck
+        'GET ': controller.healthcheck,
+        '$default': controller.default
     }
 }

--- a/devops/scripts/deploy-serverless.sh
+++ b/devops/scripts/deploy-serverless.sh
@@ -38,7 +38,7 @@ rm ../builds/lambdas/*.zip
 cd ../../app/src/lambda
 
 logYellow "Installing dependencies"
-npm install
+npm install --omit=dev
 
 logYellow "Building new zip files"
 for file in $(ls -d */); do

--- a/devops/terraform/modules/s3-site/main.tf
+++ b/devops/terraform/modules/s3-site/main.tf
@@ -165,8 +165,8 @@ resource "aws_cloudfront_distribution" "distro" {
       }
 
       min_ttl                = 0
-      default_ttl            = 86400
-      max_ttl                = 31536000
+      default_ttl            = 60
+      max_ttl                = 60
       compress               = true
       viewer_protocol_policy = "https-only"
     }

--- a/devops/terraform/modules/serverless-app/main.tf
+++ b/devops/terraform/modules/serverless-app/main.tf
@@ -91,7 +91,8 @@ module "frontend_and_cache" {
     {
       id           = stage.stage_name
       domain_name  = trimprefix(aws_apigatewayv2_api.gateway.api_endpoint, "https://")
-      path_pattern = length(stage.routes) < 2 ? "${stage.path_prefix}" : "${stage.path_prefix}/*"
+      // @TODO this following line might be complete crap and the suffix doesn't matter
+      path_pattern = length([for v in stage.routes: v if v != "$default"]) < 2 ? "${stage.path_prefix}" : "${stage.path_prefix}/*"
       stage_name   = "/${stage.stage_name}"
     }
   ]


### PR DESCRIPTION
## Acceptance Criteria
The lambda endpoints now support the ANY and default endpoints

## Change Description
The lambda endpoints now support the ANY and default endpoints

## Verification Instructions

1. Run the app locally in lambda mode and adjust the health check endpoint to ANY
2. curl the healthcheck endpoint with both get and post and confirm they work
3. adjust the healthcheck endpoint path to be just $default
4. curl the healthcheck endpoitn as well as any text after that base path

## Commit Message
fix: lambda endpoints now support the ANY and $default options
fix: adjusts the lambda npm install to omit dev when deploying
