### PR TITLE
Fixes the s3 deploys to no longer have terraform deploy the app files…

### DIFF
--- a/devops/scripts/deploy-serverless.sh
+++ b/devops/scripts/deploy-serverless.sh
@@ -8,9 +8,10 @@ logYellow() {
 
 if [[ "$1" == "test" ]]; then
     tg_location="<TG_LOCATION>"
-    s3_bucket="<S3_BUCKET_TO_DEPLOY_LAMBDA_CODE_TO_WITH_THIS_ENDING_SLASH>/"
-    s3_prefix="<S3_PREFIX_IF_YOU_NEST_THE_FUNCTIONS_IN_FOLDERS>"
-    s3_uri="$s3_bucket$s3_prefix"
+    s3_backend_bucket="<S3_BUCKET_TO_DEPLOY_LAMBDA_CODE_TO_WITH_THIS_ENDING_SLASH>/"
+    s3_backend_prefix="<S3_PREFIX_IF_YOU_NEST_THE_FUNCTIONS_IN_FOLDERS>"
+    s3_backend_uri="$s3_bucket$s3_prefix"
+    s3_ui_path"<S3_URI_AND_PATH_TO_UI_FILES>"
 else
     logYellow "Please enter a valid environment to use"
     exit 1
@@ -22,9 +23,8 @@ if [[ "$2" == "" ]]; then
     logYellow "No optional tag provided, using the git commit: $current_tag"
 fi
 
-# This is the UI built and ready to deploy
-# @TODO fix this so a user doesn't need to build the ui first to do any TG updates
 logYellow "Building the UI"
+cd ../../
 docker-compose build app
 docker-compose run app s3-build
 
@@ -33,27 +33,36 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+logYellow "Pushing UI code to S3"
+docker-compose run devops bash -c "aws s3 cp /root/repo/app/bin s3://$s3_ui_path$current_tag --recursive"
+echo -n $current_tag > $tg_location/ui-tag.txt
+
 logYellow "Cleaning out old zip files"
-rm ../builds/lambdas/*.zip
-cd ../../app/src/lambda
+rm devops/builds/lambdas/*.zip
+cd app/src/lambda
 
 logYellow "Installing dependencies"
 npm install --omit=dev
 
 logYellow "Building new zip files"
-for file in $(ls -d */); do
-    if test -f "$(pwd)/${file}index.js"; then
+for f in $(ls -d */); do
+    file="$(echo $f | grep -oE "[^/]+")"
+    if [ "$file" == "node_modules" ] || [ "$file" == "shared" ]; then
+        continue
+    fi
+    logYellow "Creating $file lambda zip"
+
+    if test -f "$(pwd)/${file}/index.js"; then
         overwriteFile=false
     else
         overwriteFile=true
     fi
 
-    cp -n index.js ./$file
+    cp -n index.js ./$file/
     cd $file
-    rm -r ./node_modules
     mv ../node_modules ./
-    zipFile="$current_tag-$(echo $file | grep -oE "[^/]+").zip"
-    zip -r $zipFile ./*
+    zipFile="$current_tag-$file.zip"
+    zip -q -r $zipFile ./*
     mv ./node_modules ../
 
     if [[ "$overwriteFile" == "true" ]]; then
@@ -64,13 +73,14 @@ for file in $(ls -d */); do
     rm $zipFile
     cd ..
 done
+rm -r ./node_modules
 
 logYellow "Copying new lambda zips to S3"
-docker-compose run devops bash -c "aws s3 cp /root/repo/devops/builds/lambdas/ s3://$s3_uri --recursive --exclude \"*\" --include \"*.zip\""
+docker-compose run devops bash -c "aws s3 cp /root/repo/devops/builds/lambdas/ s3://$s3_backend_uri --recursive --exclude \"*\" --include \"*.zip\""
 
 logYellow "Generating new lambda config for terraform"
 # @TODO: Is it worth making an entrypoint for the devops container to avoid these problems of environment?
-docker-compose run -w /root/repo/app devops bash -c "source ~/.bashrc && npm run get-lambda-config $current_tag \"$s3_prefix\" $tg_location/lambda.json"
-docker-compose run -w $tg_location devops bash -c "echo $current_tag > ./deployTag.txt"
-docker-compose run -w $tg_location devops bash -c "terragrunt apply"
+docker-compose run -w /root/repo/app devops bash -c "source ~/.bashrc && npm run get-lambda-config $current_tag \"$s3_backend_prefix\" /root/repo/$tg_location/lambda.json"
+docker-compose run -w /root/repo/$tg_location devops bash -c "echo $current_tag > ./deployTag.txt"
+docker-compose run -w /root/repo/$tg_location devops bash -c "terragrunt apply"
 

--- a/devops/terraform/modules/s3-site/input.tf
+++ b/devops/terraform/modules/s3-site/input.tf
@@ -12,7 +12,7 @@ variable "host_s3_bucket" {
 variable "s3_prefix" {
   type        = string
   default     = ""
-  description = "Prefix to use when storing the site in s3"
+  description = "Path in S3 the ui is deployed to"
 
   validation {
     condition     = can(regex("^[^\\/](?:.*[^\\/])?$", var.s3_prefix))
@@ -23,11 +23,6 @@ variable "s3_prefix" {
 variable "cname" {
   type        = string
   description = "CNAME to use when hosting the site"
-}
-
-variable "path_to_app" {
-  type        = string
-  description = "Absolute path to the files to serve via s3"
 }
 
 variable "acm_arn" {

--- a/devops/terraform/modules/s3-site/main.tf
+++ b/devops/terraform/modules/s3-site/main.tf
@@ -18,51 +18,6 @@ resource "aws_s3_bucket_website_configuration" "s3_site" {
   ]
 }
 
-#Upload files of your static website
-# @TODO: kill these resources. Do not manages the files here
-# It will wreak havoc when there are multiple devs
-resource "aws_s3_object" "html" {
-  for_each = fileset(var.path_to_app, "/**/*.html")
-
-  bucket       = var.host_s3_bucket
-  key          = "${var.s3_prefix}/${each.value}"
-  source       = "${var.path_to_app}${each.value}"
-  etag         = filemd5("${var.path_to_app}${each.value}")
-  content_type = "text/html"
-
-  depends_on = [
-    aws_s3_bucket_website_configuration.s3_site
-  ]
-}
-
-resource "aws_s3_object" "css" {
-  for_each = fileset(var.path_to_app, "/**/*.css")
-
-  bucket       = var.host_s3_bucket
-  key          = "${var.s3_prefix}/${each.value}"
-  source       = "${var.path_to_app}${each.value}"
-  etag         = filemd5("${var.path_to_app}${each.value}")
-  content_type = "text/css"
-
-  depends_on = [
-    aws_s3_bucket_website_configuration.s3_site
-  ]
-}
-
-resource "aws_s3_object" "js" {
-  for_each = fileset(var.path_to_app, "/**/*.js")
-
-  bucket       = var.host_s3_bucket
-  key          = "${var.s3_prefix}/${each.value}"
-  source       = "${var.path_to_app}${each.value}"
-  etag         = filemd5("${var.path_to_app}${each.value}")
-  content_type = "application/javascript"
-
-  depends_on = [
-    aws_s3_bucket_website_configuration.s3_site
-  ]
-}
-
 # Add more aws_s3_bucket_object for the type of files you want to upload
 # The reason for having multiple aws_s3_bucket_object with file type is to make sure
 # we add the correct content_type for the file in S3. Otherwise website load may have issues

--- a/devops/terraform/modules/s3-site/output.tf
+++ b/devops/terraform/modules/s3-site/output.tf
@@ -2,8 +2,3 @@
 output "cloudfront_domain_name" {
   value = aws_cloudfront_distribution.distro.domain_name
 }
-
-# Print the files processed so far
-output "fileset-results" {
-  value = fileset(var.path_to_app, "**/*")
-}

--- a/devops/terraform/modules/serverless-app/input.tf
+++ b/devops/terraform/modules/serverless-app/input.tf
@@ -64,17 +64,12 @@ variable "cname" {
 
 variable "s3_prefix" {
   type        = string
-  description = "Prefix to use when storing the site in s3"
+  description = "Path in S3 the ui is stored in"
 
   validation {
     condition     = can(regex("^[^\\/](?:.*[^\\/])?$", var.s3_prefix))
     error_message = "No leading or trailing slashes are allowed."
   }
-}
-
-variable "ui_files" {
-  type        = string
-  description = "Absolute path to the files to serve via s3"
 }
 
 variable "secrets" {

--- a/devops/terraform/modules/serverless-app/main.tf
+++ b/devops/terraform/modules/serverless-app/main.tf
@@ -85,7 +85,6 @@ module "frontend_and_cache" {
   acm_arn     = var.acm_arn
   cname       = var.cname
   s3_prefix   = var.s3_prefix
-  path_to_app = var.ui_files
   apigateway_origins = [
     for stage in module.backend :
     {

--- a/devops/terragrunt-examples/aws/s3/terragrunt.hcl
+++ b/devops/terragrunt-examples/aws/s3/terragrunt.hcl
@@ -4,6 +4,7 @@ terraform {
 
 locals {
     region = "us-east-1"
+    ui_tag = file("ui-tag.txt")
 }
 
 # Indicate the input values to use for the variables of the module.
@@ -15,8 +16,7 @@ inputs = {
     # only then can you deploy everything else
     # acm_arn = "arn:aws:acm:us-east-1:0123456789:certificate/abc123"
     cname = "PRIMARY_URL_TO_HOST_FROM"
-    s3_prefix = "dev"
-    path_to_app = "${get_terragrunt_dir()}/../../../app/bin/"
+    s3_prefix = "dev/${local.ui_tag}"
 
   tags = {
     Environment = "dev"

--- a/devops/terragrunt-examples/aws/serverless-fullstack/terragrunt.hcl
+++ b/devops/terragrunt-examples/aws/serverless-fullstack/terragrunt.hcl
@@ -7,6 +7,7 @@ locals {
     environment = "dev"
     # secrets = yamldecode(sops_decrypt_file("secrets.yml"))
     deploy_tag = file("deployTag.txt")
+    ui_tag = file("ui-tag.txt")
     function_configs = jsondecode(file("lambda.json"))
     default_env_vars = {
       LOG_LEVEL = "debug"
@@ -68,8 +69,7 @@ inputs = {
   # only then can you deploy everything else
   acm_arn = "CERT_ARN"
   cname = "ALTERNATE_CNAME"
-  s3_prefix = "dev"
-  ui_files = "${get_terragrunt_dir()}/../../../app/bin/"
+  s3_prefix = "dev/${local.ui_tag}"
 }
 
 # If you desire to use a remote state for multiple devs or branches


### PR DESCRIPTION
## Acceptance Criteria
Running a terragrunt deploy for s3 no longer depends on having the correct version of the app ui built in the repo

## Change Description
Updates terraform to no longer be responsible for deploy the ui files to s3, that is now the job of the deploy script. Instead terraform now picks which version of the ui in s3 to point cloudfront to. This will make roll backs much easier and no require a dev to build the ui just to run a terraform update

## Verification Instructions
1. Deploy either the s3 only for full serverless app
2. delete all files under the app/bin folder
3. run a terragrunt apply from the same deploy without running the deploy script. It shouldn't break the deployed app or do any changes

## Commit Message
feat: Terraform now allows for ui versioning in s3
feat: updates the s3 deploy script to now use docker when deploying
fix: developers no longer need to build the ui just to run terragrunt for s3 sites
chore: silences the zip commands for the serverless deploy
